### PR TITLE
Implement favorites feature

### DIFF
--- a/livraria/app/Http/Controllers/FavoriteController.php
+++ b/livraria/app/Http/Controllers/FavoriteController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Livro;
+use Illuminate\Support\Facades\Auth;
+
+class FavoriteController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function toggle(Livro $livro)
+    {
+        $user = Auth::user();
+
+        if ($user->favorites()->where('livro_id', $livro->id)->exists()) {
+            $user->favorites()->detach($livro->id);
+            $favorited = false;
+        } else {
+            $user->favorites()->attach($livro->id);
+            $favorited = true;
+        }
+
+        return response()->json(['favorited' => $favorited]);
+    }
+}

--- a/livraria/app/Models/Favorite.php
+++ b/livraria/app/Models/Favorite.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Favorite extends Model
+{
+    protected $fillable = ['user_id', 'livro_id'];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function livro()
+    {
+        return $this->belongsTo(Livro::class);
+    }
+}

--- a/livraria/app/Models/Livro.php
+++ b/livraria/app/Models/Livro.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Storage;
+use App\Models\User;
 
 class Livro extends Model
 {
@@ -131,5 +132,10 @@ class Livro extends Model
     {
         $this->increment('estoque', $quantidade);
         return true;
+    }
+
+    public function favoritedBy()
+    {
+        return $this->belongsToMany(User::class, 'favorites')->withTimestamps();
     }
 }

--- a/livraria/app/Models/User.php
+++ b/livraria/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use App\Models\Livro;
 
 class User extends Authenticatable
 {
@@ -44,5 +45,10 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function favorites()
+    {
+        return $this->belongsToMany(Livro::class, 'favorites')->withTimestamps();
     }
 }

--- a/livraria/database/migrations/2025_05_29_000000_create_favorites_table.php
+++ b/livraria/database/migrations/2025_05_29_000000_create_favorites_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('favorites', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('livro_id')->constrained('livros')->onDelete('cascade');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'livro_id']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('favorites');
+    }
+};

--- a/livraria/resources/views/layouts/app.blade.php
+++ b/livraria/resources/views/layouts/app.blade.php
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>@yield('title', 'Biblioteca Literária')</title>
     
     <!-- Google Fonts -->

--- a/livraria/resources/views/livros/index.blade.php
+++ b/livraria/resources/views/livros/index.blade.php
@@ -163,9 +163,12 @@
                     
                     <!-- Favorite Icon -->
                     <div class="position-absolute top-0 start-0 m-2">
-                        <button class="btn btn-sm btn-light rounded-circle" onclick="toggleFavorite({{ $livro->id }})" 
+                        @php
+                            $isFav = auth()->check() && auth()->user()->favorites()->where('livro_id', $livro->id)->exists();
+                        @endphp
+                        <button class="btn btn-sm btn-light rounded-circle" data-favorite-button="{{ $livro->id }}" onclick="toggleFavorite({{ $livro->id }})"
                                 data-bs-toggle="tooltip" title="Adicionar aos favoritos">
-                            <i class="far fa-heart"></i>
+                            <i class="{{ $isFav ? 'fas' : 'far' }} fa-heart" @if($isFav) style="color:#dc3545" @endif></i>
                         </button>
                     </div>
                 </div>
@@ -310,22 +313,27 @@
 <!-- JavaScript for favorites -->
 <script>
 function toggleFavorite(livroId) {
-    // Implementar funcionalidade de favoritos se necessário
-    console.log('Favorito clicado para livro:', livroId);
-    
-    // Por enquanto, apenas mudamos o ícone
-    const button = event.currentTarget;
-    const icon = button.querySelector('i');
-    
-    if (icon.classList.contains('far')) {
-        icon.classList.remove('far');
-        icon.classList.add('fas');
-        icon.style.color = '#dc3545';
-    } else {
-        icon.classList.remove('fas');
-        icon.classList.add('far');
-        icon.style.color = '';
-    }
+    fetch('/livros/' + livroId + '/favorite', {
+        method: 'POST',
+        headers: {
+            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+            'Accept': 'application/json'
+        }
+    })
+    .then(response => response.json())
+    .then(data => {
+        const button = document.querySelector('[data-favorite-button="' + livroId + '"]');
+        const icon = button.querySelector('i');
+        if (data.favorited) {
+            icon.classList.remove('far');
+            icon.classList.add('fas');
+            icon.style.color = '#dc3545';
+        } else {
+            icon.classList.remove('fas');
+            icon.classList.add('far');
+            icon.style.color = '';
+        }
+    });
 }
 
 // Initialize tooltips

--- a/livraria/routes/web.php
+++ b/livraria/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\LivroController;
 use App\Http\Controllers\CategoriaController;
 use App\Http\Controllers\HomeController;
+use App\Http\Controllers\FavoriteController;
 
 // Página inicial redireciona para o catálogo de livros
 Route::get('/', function () {
@@ -12,6 +13,7 @@ Route::get('/', function () {
 
 // Rotas para Livros
 Route::resource('livros', LivroController::class);
+Route::post('livros/{livro}/favorite', [FavoriteController::class, 'toggle'])->name('livros.favorite');
 
 // Rotas para Categorias (se você quiser usar)
 Route::resource('categorias', CategoriaController::class);

--- a/livraria/tests/Feature/ExampleTest.php
+++ b/livraria/tests/Feature/ExampleTest.php
@@ -14,6 +14,6 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertRedirect('/livros');
     }
 }


### PR DESCRIPTION
## Summary
- create favorites pivot table
- add `Favorite` model and relationships
- enable toggling favorites via controller and route
- show AJAX favorite button on book index
- provide CSRF token meta tag
- adjust feature test to expect redirect

## Testing
- `composer install --no-interaction`
- `php artisan migrate --force`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6840a3b106dc83278123f5d47d6f1e80