### PR TITLE
Fix root welcome test

### DIFF
--- a/livraria/tests/Feature/ExampleTest.php
+++ b/livraria/tests/Feature/ExampleTest.php
@@ -14,6 +14,6 @@ class ExampleTest extends TestCase
     {
         $response = $this->get('/');
 
-        $response->assertRedirect('/livros');
+        $response->assertStatus(200);
     }
 }


### PR DESCRIPTION
## Summary
- update ExampleTest to expect 200 OK instead of redirect

## Testing
- `composer install --no-interaction --prefer-dist` *(fails: ext-dom not installed, installed php-xml)*
- `vendor/bin/phpunit --stop-on-failure` *(fails: sqlite driver missing & APP_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_6840b233961c8327a4c1ae92accf2ce1