### PR TITLE
Fix user ID update in checkout

### DIFF
--- a/livraria/app/Http/Controllers/CartController.php
+++ b/livraria/app/Http/Controllers/CartController.php
@@ -96,7 +96,7 @@ class CartController extends Controller
 
         $cart->update([
             'status' => 'completed',
-            'user_id' => $userId,
+            'user_id' => auth()->id(),
         ]);
         session()->forget('cart_id');
 


### PR DESCRIPTION
## Summary
- fix checkout cart update to use authenticated user ID

## Testing
- `php artisan test` *(fails: missing PHP extensions)*

------
https://chatgpt.com/codex/tasks/task_e_6845e05839988327b4d90c1f7f34e2c2