### PR TITLE
Fix duplicated generos array in LivroController

### DIFF
--- a/livraria/app/Http/Controllers/LivroController.php
+++ b/livraria/app/Http/Controllers/LivroController.php
@@ -188,10 +188,6 @@ class LivroController extends Controller
             'ficcao' => 'Ficção',
             'nao_ficcao' => 'Não-ficção',
             'romance' => 'Romance',
-        $generos = [
-            'ficcao' => 'Ficção',
-            'nao_ficcao' => 'Não-ficção',
-            'romance' => 'Romance',
             'fantasia' => 'Fantasia',
             'misterio' => 'Mistério',
             'biografia' => 'Biografia',
@@ -204,7 +200,7 @@ class LivroController extends Controller
             'academico' => 'Acadêmico'
         ];
         
-        return view('livros.edit', compact('livro', 'categorias', 'editoras', 'generos'));
+        return view('livros.create', compact('categorias', 'editoras', 'generos'));
     }
 
     public function update(LivroRequest $request, Livro $livro)


### PR DESCRIPTION
## Summary
- fix the `create` method to only assign `$generos` once
- return the proper view using the `$generos` variable

## Testing
- `composer install --no-interaction`
- `composer test` *(fails: could not find driver / MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_6845e057402883279c8c7d73d6e5ff73