### PR TITLE
Fix payment method in CheckoutTest

### DIFF
--- a/livraria/tests/Feature/CheckoutTest.php
+++ b/livraria/tests/Feature/CheckoutTest.php
@@ -39,6 +39,7 @@ class CheckoutTest extends TestCase
             'state' => 'TS',
             'zip' => '12345',
             'country' => 'Testland',
+            'payment_method' => 'pix',
         ];
         $response = $this->post('/checkout', $checkoutData);
         $response->assertStatus(200);


### PR DESCRIPTION
## Summary
- ensure CheckoutTest sends a valid payment method value

## Testing
- `php artisan test` *(fails: could not find driver / expected 200 but got 302, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68460747d488832799225650e2501d4f