### PR TITLE
Add auth links to navbar

### DIFF
--- a/livraria/resources/views/layouts/app.blade.php
+++ b/livraria/resources/views/layouts/app.blade.php
@@ -438,6 +438,16 @@
                             <i class="fas fa-list me-1"></i> Meus Pedidos
                         </a>
                     @endauth
+                    @guest
+                        <a class="nav-link" href="{{ route('login') }}">
+                            <i class="fas fa-sign-in-alt me-1"></i> Login
+                        </a>
+                        @if (Route::has('register'))
+                            <a class="nav-link" href="{{ route('register') }}">
+                                <i class="fas fa-user-plus me-1"></i> Registrar-se
+                            </a>
+                        @endif
+                    @endguest
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- show login and register links in the navbar

## Testing
- `php artisan test --stop-on-failure` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460ce6a65083279af6d70371816fd1