### PR TITLE
Fix category seeder slug generation

### DIFF
--- a/livraria/app/Models/Categoria.php
+++ b/livraria/app/Models/Categoria.php
@@ -14,7 +14,8 @@ class Categoria extends Model
         'nome',
         'descricao',
         'imagem',
-        'ativo'
+        'ativo',
+        'slug'
     ];
 
     protected $casts = [

--- a/livraria/database/seeders/CategoriaSeeder.php
+++ b/livraria/database/seeders/CategoriaSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
 use App\Models\Categoria;
 
 class CategoriaSeeder extends Seeder
@@ -38,7 +39,12 @@ class CategoriaSeeder extends Seeder
         ];
 
         foreach ($categorias as $categoria) {
-            Categoria::create($categoria);
+            Categoria::create([
+                'nome' => $categoria['nome'],
+                'descricao' => $categoria['descricao'],
+                'ativo' => $categoria['ativo'],
+                'slug' => Str::slug($categoria['nome']),
+            ]);
         }
     }
 }


### PR DESCRIPTION
## Summary
- include slug field in Categoria seeder
- allow slug mass-assignment on Categoria model

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ffa6a8708327b5e9718e43c5761d